### PR TITLE
Set default value for sortParameters to null

### DIFF
--- a/src/Http/Query/ListQueryParameters.php
+++ b/src/Http/Query/ListQueryParameters.php
@@ -50,7 +50,7 @@ class ListQueryParameters extends QueryParameters
      */
     #[API\Property(path: '[sort]', parser: 'parseSortingParameters')]
     #[Assert\Type('array')]
-    protected ?array $sortParameters;
+    protected ?array $sortParameters = null;
 
     /**
      * @param int|null $pageNumber


### PR DESCRIPTION
Previously, the sortParameters property was uninitialized, which cause could lead to unexpected behavior. This change ensures it has a default null value, improving consistency and preventing potential issues.