### PR TITLE
Fix uncaught \TypeError when two relationships collide by (type, id)

### DIFF
--- a/src/Decoders/DataParser.php
+++ b/src/Decoders/DataParser.php
@@ -906,6 +906,7 @@ class DataParser implements DataParserInterface
 
         if ((null !== $resId) &&
             (null !== $resType) &&
+            (true === $this->isExpectedResourceType($resType, $relationship->getDataTypeParams())) &&
             (null !== ($res = $this->context->getResource($resType, $resId)))
         ) {
             return $this->setProperty($pathValue, $res, $relationship);
@@ -948,14 +949,15 @@ class DataParser implements DataParserInterface
                 $resId = $this->getValue($data, $path . '.id');
             }
 
+            $params = $relationship->getDataTypeParams();
+
             if ((null !== $resType) &&
                 (null !== $resId) &&
+                (true === $this->isExpectedResourceType($resType, $params[1])) &&
                 (null !== ($parsed = $this->context->getResource($resType, $resId)))
             ) {
                 return $parsed;
             }
-
-            $params = $relationship->getDataTypeParams();
 
             if (null !== ($linkedData = $this->context->getLinkedData($resType, $resId))) {
                 $idx = $this->context->getLinkedDataIndex($resType, $resId);
@@ -982,6 +984,35 @@ class DataParser implements DataParserInterface
         if (is_array($data)) {
             $this->setProperty($pathValue, $data, $relationship);
         }
+    }
+
+    /**
+     * Checks that the resource type provided in request matches the type
+     * expected by the relationship.
+     *
+     * Relationship "fast paths" look up an already parsed resource in the
+     * context by the (type, id) pair taken from the request. Without this
+     * check a resource of a different type registered under the same
+     * (type, id) by another relationship would be reused as-is and passed to
+     * a setter that expects a different class, raising an uncaught \TypeError
+     * (HTTP 500) instead of a proper "wrong type" error. When the type does
+     * not match we skip the fast path and fall back to regular parsing, which
+     * reports the type mismatch the same way as {@see parseResource()}.
+     *
+     * @param string|null $resType Resource type provided in request
+     * @param string $resClass Class expected by the relationship
+     * @return bool
+     */
+    private function isExpectedResourceType($resType, $resClass)
+    {
+        if (null === $resType) {
+            return false;
+        }
+
+        $metadata = $this->factory->getMetadataFor($resClass);
+
+        return ($metadata instanceof ResourceMetadataInterface) &&
+            ($resType === $metadata->getName());
     }
 
     /**

--- a/tests/Decoders/DataParserTest.php
+++ b/tests/Decoders/DataParserTest.php
@@ -25,6 +25,7 @@ use Reva2\JsonApi\Tests\Fixtures\Metadata\PetsListMetadata;
 use Reva2\JsonApi\Tests\Fixtures\Objects\AnotherObject;
 use Reva2\JsonApi\Tests\Fixtures\Objects\BaseObject;
 use Reva2\JsonApi\Tests\Fixtures\Objects\ExampleObject;
+use Reva2\JsonApi\Tests\Fixtures\Resources\Cart;
 use Reva2\JsonApi\Tests\Fixtures\Resources\Cat;
 use Reva2\JsonApi\Tests\Fixtures\Resources\Dog;
 use Reva2\JsonApi\Tests\Fixtures\Resources\Person;
@@ -305,6 +306,43 @@ class DataParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(Something::class, $result->getVirtualRel());
         $this->assertSame('test', $result->getVirtualRel()->id);
+    }
+
+    /**
+     * Two relationships of different types may reference the same (type, id)
+     * pair in a request. The resource registered in the parsing context by the
+     * first relationship must not be reused for the second one when its type
+     * does not match: otherwise a resource of the wrong class is passed to a
+     * type hinted setter, which raises an uncaught \TypeError (HTTP 500)
+     * instead of a proper "wrong type" error. With the type check in place the
+     * mismatch is reported the same way as for a standalone resource.
+     *
+     * @test
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionCode 409
+     * @expectedExceptionMessageRegExp #Value must contain resource of type 'persons'#
+     */
+    public function shouldNotReuseContextResourceOfDifferentTypeForRelationship()
+    {
+        $data = json_decode(json_encode([
+            'cart' => [
+                'type' => 'carts',
+                'id' => '1',
+                'relationships' => [
+                    'store' => [
+                        'data' => ['type' => 'stores', 'id' => 'shared-id'],
+                    ],
+                    // "owner" must reference a "persons" resource, but the
+                    // request mislabels it with the "store" relationship type
+                    // and reuses the same id, so it collides in the context.
+                    'owner' => [
+                        'data' => ['type' => 'stores', 'id' => 'shared-id'],
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->parser->parseResource($data, 'cart', Cart::class);
     }
 
     /**

--- a/tests/Fixtures/Resources/Cart.php
+++ b/tests/Fixtures/Resources/Cart.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * This file is part of the reva2/jsonapi.
+ *
+ * (c) Sergey Revenko <dedsemen@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Reva2\JsonApi\Tests\Fixtures\Resources;
+
+use Reva2\JsonApi\Annotations as API;
+
+/**
+ * Example JSON API resource with two to-one relationships of different types
+ * and type hinted setters. Used to cover the case when two relationships
+ * reference the same (type, id) pair: a resource of the wrong type must not be
+ * reused from the parsing context and passed to a setter expecting another
+ * class.
+ *
+ * @package Reva2\JsonApi\Tests\Fixtures\Resources
+ * @author Sergey Revenko <dedsemen@gmail.com>
+ *
+ * @API\ApiResource("carts")
+ */
+class Cart
+{
+    /**
+     * @var string
+     * @API\Id()
+     */
+    public $id;
+
+    /**
+     * @var Store
+     * @API\Relationship(type="Reva2\JsonApi\Tests\Fixtures\Resources\Store")
+     */
+    protected $store;
+
+    /**
+     * @var Person
+     * @API\Relationship(type="Reva2\JsonApi\Tests\Fixtures\Resources\Person")
+     */
+    protected $owner;
+
+    /**
+     * @param Store $store
+     * @return $this
+     */
+    public function setStore(Store $store)
+    {
+        $this->store = $store;
+
+        return $this;
+    }
+
+    /**
+     * @return Store
+     */
+    public function getStore()
+    {
+        return $this->store;
+    }
+
+    /**
+     * @param Person $owner
+     * @return $this
+     */
+    public function setOwner(Person $owner)
+    {
+        $this->owner = $owner;
+
+        return $this;
+    }
+
+    /**
+     * @return Person
+     */
+    public function getOwner()
+    {
+        return $this->owner;
+    }
+}


### PR DESCRIPTION
The relationship fast path looks up an already parsed resource in the context by the (type, id) pair taken from the request and assigns it without verifying its class. When two relationships of different types reference the same (type, id) -- e.g. a request mislabels one relationship with another's type and reuses its id -- the resource registered by the first relationship is reused for the second one and passed to a type hinted setter expecting a different class. This raises an uncaught \TypeError (HTTP 500) instead of a proper "wrong type" error, since parseDocument() only catches \Exception.

Skip the context fast path when the request type does not match the type expected by the relationship, so parsing falls back to parseResource(), which reports the mismatch as a 409 -- exactly as for a standalone resource. Covers both to-one and to-many relationships.